### PR TITLE
Validate LLM actions and add tests

### DIFF
--- a/src/llm.test.ts
+++ b/src/llm.test.ts
@@ -1,0 +1,41 @@
+import { classifyEmail } from './llm';
+
+describe('classifyEmail action validation', () => {
+  const baseResponse = {
+    category: 'Orders',
+    folder: 'Orders',
+    confidence: 0.9,
+  };
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('defaults unknown action to ignore', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          response: JSON.stringify({ ...baseResponse, action: 'delete' }),
+        }),
+      })
+    ) as any;
+
+    const decision = await classifyEmail({ from: '', subject: '', content: '' });
+    expect(decision.action).toBe('ignore');
+  });
+
+  test('accepts valid action', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          response: JSON.stringify({ ...baseResponse, action: 'move' }),
+        }),
+      })
+    ) as any;
+
+    const decision = await classifyEmail({ from: '', subject: '', content: '' });
+    expect(decision.action).toBe('move');
+  });
+});


### PR DESCRIPTION
## Summary
- restrict decisions to allowed actions
- default to ignore for invalid LLM actions
- add unit tests for action validation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689864a13b1c832391aa32404c1f41df