### PR TITLE
Validate Microsoft client ID before Graph config

### DIFF
--- a/src/graph.test.ts
+++ b/src/graph.test.ts
@@ -1,3 +1,4 @@
+process.env.MICROSOFT_CLIENT_ID = 'test-client-id';
 import { MicrosoftGraphClient } from './graph';
 import { logger } from './logger';
 

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -12,6 +12,16 @@ import { logger } from './logger.js';
 
 const execAsync = promisify(exec);
 
+function getRequiredEnvVar(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    const message = `Environment variable ${name} is required`;
+    logger.error(message);
+    throw new Error(message);
+  }
+  return value;
+}
+
 interface GraphEmail {
   id: string;
   subject: string;
@@ -50,7 +60,7 @@ class MSALAuthenticationProvider implements AuthenticationProvider {
 export class MicrosoftGraphClient {
   private msalConfig = {
     auth: {
-      clientId: process.env.MICROSOFT_CLIENT_ID!,
+      clientId: getRequiredEnvVar('MICROSOFT_CLIENT_ID'),
       authority: `https://login.microsoftonline.com/${process.env.MICROSOFT_TENANT_ID || 'consumers'}`,
       ...(process.env.MICROSOFT_CLIENT_SECRET && {
         clientSecret: process.env.MICROSOFT_CLIENT_SECRET


### PR DESCRIPTION
## Summary
- ensure MICROSOFT_CLIENT_ID env var is defined before building MSAL configuration
- provide helper to validate required env vars
- set client ID in tests for MicrosoftGraphClient

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689868a116808323b73080376a080e43