### PR TITLE
Handle missing email folders gracefully

### DIFF
--- a/src/graph.ts
+++ b/src/graph.ts
@@ -517,7 +517,7 @@ export class MicrosoftGraphClient {
       return folderId;
     } catch (error: any) {
       // In case of error, use existing folder as fallback
-      logger.warn(`Issue with folder ${name}, using fallback`);
+      logger.warn(`Issue with folder ${name}, attempting fallback`);
       try {
         const inboxSubfolders = await this.getInboxSubfolders();
 
@@ -532,13 +532,10 @@ export class MicrosoftGraphClient {
           return fallbackFolder.id;
         }
 
-        // Last resort: use inbox
-        logger.debug(`Using inbox`);
-        const inboxId = await this.getInboxId();
-        this.folderCache.set(key, inboxId);
-        return inboxId;
+        logger.warn(`No available target folder for ${name}`);
+        throw error;
 
-      } catch (fallbackError) {
+      } catch {
         throw error; // Re-throw original error
       }
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -114,15 +114,29 @@ async function applyDecision(client: MicrosoftGraphClient, email: GraphEmail, de
     }
 
     if (decision.action === 'move' && decision.folder) {
-      const folderId = await client.ensureFolder(decision.folder);
-      await client.moveEmail(email.id, folderId);
-      // Note: No need to markAsRead after move as email is already processed
+      let folderId: string | null = null;
+      try {
+        folderId = await client.ensureFolder(decision.folder);
+      } catch (err: any) {
+        logger.warn(`Skipping move for ${email.id.slice(-8)}: ${err?.message || err}`);
+      }
+      if (folderId) {
+        await client.moveEmail(email.id, folderId);
+        // Note: No need to markAsRead after move as email is already processed
+      }
     } else if (decision.action === 'mark_read') {
       await client.markAsRead(email.id);
     } else if (decision.action === 'archive') {
-      const archiveFolderId = await client.ensureFolder('Archive');
-      await client.moveEmail(email.id, archiveFolderId);
-      // Note: No need to markAsRead after move as email is already processed
+      let archiveFolderId: string | null = null;
+      try {
+        archiveFolderId = await client.ensureFolder('Archive');
+      } catch (err: any) {
+        logger.warn(`Skipping archive for ${email.id.slice(-8)}: ${err?.message || err}`);
+      }
+      if (archiveFolderId) {
+        await client.moveEmail(email.id, archiveFolderId);
+        // Note: No need to markAsRead after move as email is already processed
+      }
     }
     // 'ignore': do nothing
   } catch (error: any) {


### PR DESCRIPTION
## Summary
- avoid falling back to Inbox when ensureFolder fails
- warn and abort when no target folder exists during applyDecision

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68986c60a730832396af6eb2e625af3d