### PR TITLE
Check email move result

### DIFF
--- a/src/graph.test.ts
+++ b/src/graph.test.ts
@@ -1,4 +1,5 @@
 process.env.MICROSOFT_CLIENT_ID = 'test-client-id';
+process.env.LOG_LEVEL = 'debug';
 import { MicrosoftGraphClient } from './graph';
 import { logger } from './logger';
 
@@ -63,5 +64,31 @@ describe('startLocalServer', () => {
     expect(warnSpy).not.toHaveBeenCalled();
 
     warnSpy.mockRestore();
+  });
+});
+
+describe('moveEmail', () => {
+  it('logs warning when email stays in same folder', async () => {
+    const client = new MicrosoftGraphClient();
+    const mockPost = jest.fn().mockResolvedValue({ id: '1', parentFolderId: 'source' });
+    (client as any).graphClient = {
+      api: () => ({ post: mockPost })
+    };
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    await client.moveEmail('1', 'dest', 'source');
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('logs debug when email moves to a different folder', async () => {
+    const client = new MicrosoftGraphClient();
+    const mockPost = jest.fn().mockResolvedValue({ id: '1', parentFolderId: 'dest' });
+    (client as any).graphClient = {
+      api: () => ({ post: mockPost })
+    };
+    const debugSpy = jest.spyOn(logger, 'debug').mockImplementation(() => {});
+    await client.moveEmail('1', 'dest', 'source');
+    expect(debugSpy).toHaveBeenCalled();
+    debugSpy.mockRestore();
   });
 });

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -414,18 +414,23 @@ export class MicrosoftGraphClient {
     }
   }
 
-  async moveEmail(emailId: string, folderId: string): Promise<void> {
+  async moveEmail(emailId: string, folderId: string, sourceFolderId: string): Promise<void> {
     if (!this.graphClient) {
       throw new Error('Client not authenticated');
     }
 
     try {
-      await this.graphClient
+      const result = await this.graphClient
         .api(`/me/messages/${emailId}/move`)
-        .post({
+        .post<{ id: string; parentFolderId: string }>({
           destinationId: folderId
         });
-      logger.debug(`Email moved: ${emailId.slice(-8)}`);
+
+      if (!result?.parentFolderId || result.parentFolderId === sourceFolderId) {
+        logger.warn(`Email not moved: ${emailId.slice(-8)}`);
+      } else {
+        logger.debug(`Email moved: ${emailId.slice(-8)}`);
+      }
     } catch (error: any) {
       if (error?.code === 'ErrorItemNotFound') {
         logger.warn(`Email not found: ${emailId.slice(-8)}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -121,7 +121,7 @@ async function applyDecision(client: MicrosoftGraphClient, email: GraphEmail, de
         logger.warn(`Skipping move for ${email.id.slice(-8)}: ${err?.message || err}`);
       }
       if (folderId) {
-        await client.moveEmail(email.id, folderId);
+        await client.moveEmail(email.id, folderId, email.parentFolderId);
         // Note: No need to markAsRead after move as email is already processed
       }
     } else if (decision.action === 'mark_read') {
@@ -134,7 +134,7 @@ async function applyDecision(client: MicrosoftGraphClient, email: GraphEmail, de
         logger.warn(`Skipping archive for ${email.id.slice(-8)}: ${err?.message || err}`);
       }
       if (archiveFolderId) {
-        await client.moveEmail(email.id, archiveFolderId);
+        await client.moveEmail(email.id, archiveFolderId, email.parentFolderId);
         // Note: No need to markAsRead after move as email is already processed
       }
     }


### PR DESCRIPTION
## Summary
- verify moved message folder returned by Graph API and log warning if unchanged
- update callers to provide source folder
- add tests for moveEmail validation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68986d7016288323a3d2cd9dcc5a3ceb